### PR TITLE
Text page options

### DIFF
--- a/client/src/components/NavBar/NavBar.js
+++ b/client/src/components/NavBar/NavBar.js
@@ -17,12 +17,12 @@ const NavBar = (props) => {
   return (
     <div>
       <Navbar className="fixed-top" style={{backgroundColor:'black'}} light expand="md">
-        <Link className="text-light navbar-brand pl-5" to="/">StoryFics</Link>
+        <Link className="text-light navbar-brand pl-5" to="/">Storyfics</Link>
         <NavbarToggler style={{backgroundColor:'#1e272e'}} onClick={toggle} />
         <Collapse isOpen={isOpen} navbar>
-          <Nav className="mr-auto" navbar>
+          <Nav className="ml-auto" navbar>
             <NavItem>
-              <Link className="text-light nav-link" to="/">Titles</Link>
+              <Link className="text-light nav-link" to="/"><i className="fas fa-home"></i></Link>
             </NavItem>
             <NavItem>
               <Link className="text-light nav-link" to="/">My Library</Link>
@@ -31,9 +31,6 @@ const NavBar = (props) => {
               <Link className="text-light nav-link" to="/search">Search</Link>
             </NavItem>
           </Nav>
-          <NavbarText className="text-light pr-4">Redeem</NavbarText>
-          <span className="mx-2">|</span>
-          <NavbarText className="text-light pl-4 ">Sign In</NavbarText>
         </Collapse>
       </Navbar>
     </div>

--- a/client/src/components/TextView/TextContent/TextCard.js
+++ b/client/src/components/TextView/TextContent/TextCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-const TextCard = ({id, content, textSizeClass, fontClass, marginsClass, spacingClass}) => {
+const TextCard = ({id, content, toggleReadingNavOpen, textSizeClass, fontClass, marginsClass, spacingClass}) => {
   return (
-    <div className={`storyPage text-size-${textSizeClass} font-${fontClass} margins-${marginsClass} spacing-${spacingClass}`}>
+    <div onClick={toggleReadingNavOpen} className={`storyPage text-size-${textSizeClass} font-${fontClass} margins-${marginsClass} spacing-${spacingClass}`}>
       <p>Page {id}</p>
       <p>{content}</p>
     </div>

--- a/client/src/components/TextView/TextContent/TextCard.js
+++ b/client/src/components/TextView/TextContent/TextCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-const TextCard = ({id, content, textSizeClass, fontClass}) => {
+const TextCard = ({id, content, textSizeClass, fontClass, marginsClass}) => {
   return (
-    <div className={`storyPage text-size-${textSizeClass} font-${fontClass}`}>
+    <div className={`storyPage text-size-${textSizeClass} font-${fontClass} margins-${marginsClass}`}>
       <p>Page {id}</p>
       <p>{content}</p>
     </div>

--- a/client/src/components/TextView/TextContent/TextCard.js
+++ b/client/src/components/TextView/TextContent/TextCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-const TextCard = ({id, content}) => {
+const TextCard = ({id, content, textSizeClass}) => {
   return (
-    <div className="storyPage">
+    <div className={`storyPage text-size-${textSizeClass}`}>
       <p>Page {id}</p>
       <p>{content}</p>
     </div>

--- a/client/src/components/TextView/TextContent/TextCard.js
+++ b/client/src/components/TextView/TextContent/TextCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-const TextCard = ({id, content, textSizeClass, fontClass, marginsClass}) => {
+const TextCard = ({id, content, textSizeClass, fontClass, marginsClass, spacingClass}) => {
   return (
-    <div className={`storyPage text-size-${textSizeClass} font-${fontClass} margins-${marginsClass}`}>
+    <div className={`storyPage text-size-${textSizeClass} font-${fontClass} margins-${marginsClass} spacing-${spacingClass}`}>
       <p>Page {id}</p>
       <p>{content}</p>
     </div>

--- a/client/src/components/TextView/TextContent/TextCard.js
+++ b/client/src/components/TextView/TextContent/TextCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-const TextCard = ({id, content, textSizeClass}) => {
+const TextCard = ({id, content, textSizeClass, bgColorClass}) => {
   return (
-    <div className={`storyPage text-size-${textSizeClass}`}>
+    <div className={`storyPage text-size-${textSizeClass} bg-${bgColorClass}`}>
       <p>Page {id}</p>
       <p>{content}</p>
     </div>

--- a/client/src/components/TextView/TextContent/TextCard.js
+++ b/client/src/components/TextView/TextContent/TextCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-const TextCard = ({id, content, textSizeClass, bgColorClass}) => {
+const TextCard = ({id, content, textSizeClass, fontClass}) => {
   return (
-    <div className={`storyPage text-size-${textSizeClass} bg-${bgColorClass}`}>
+    <div className={`storyPage text-size-${textSizeClass} font-${fontClass}`}>
       <p>Page {id}</p>
       <p>{content}</p>
     </div>

--- a/client/src/components/TextView/TextContent/TextContent.css
+++ b/client/src/components/TextView/TextContent/TextContent.css
@@ -5,7 +5,8 @@
 }
 
 .text-pages-carousel-track {
-    height: 100vh;
+    margin: 3rem 0;
+    height: calc(100vh - 6rem);
 }
 
 .storyPage {

--- a/client/src/components/TextView/TextContent/TextContent.css
+++ b/client/src/components/TextView/TextContent/TextContent.css
@@ -4,10 +4,13 @@
     margin-right: auto;
 }
 
+.text-pages-carousel-track {
+    height: 100vh;
+}
 
 .storyPage {
     max-width: 50vw;
-    height: 90vh;
+    height: 100%;
     /* padding: 4rem 2rem; */
     /* padding: 8rem 2rem; */
     /* background-color: var(--background-light); */
@@ -40,18 +43,18 @@
 }
 
 .margins-1 {
-    margin-left: 1rem;
-    margin-right: 1rem;
-}
-
-.margins-2 {
     margin-left: 1.5rem;
     margin-right: 1.5rem;
 }
 
+.margins-2 {
+    margin-left: 3.5rem;
+    margin-right: 3.5rem;
+}
+
 .margins-3 {
-    margin-left: 2rem;
-    margin-right: 2rem;
+    margin-left: 5rem;
+    margin-right: 5rem;
 }
 
 
@@ -71,5 +74,20 @@
     .storyPage {
         max-width: 100vw;
         /* font-size: smaller; */
+    }
+
+    .margins-1 {
+        margin-left: 1rem;
+        margin-right: 1rem;
+    }
+
+    .margins-2 {
+        margin-left: 1.5rem;
+        margin-right: 1.5rem;
+    }
+
+    .margins-3 {
+        margin-left: 2rem;
+        margin-right: 2rem;
     }
 }

--- a/client/src/components/TextView/TextContent/TextContent.css
+++ b/client/src/components/TextView/TextContent/TextContent.css
@@ -10,7 +10,7 @@
     height: 90vh;
     /* padding: 4rem 2rem; */
     padding: 8rem 2rem;
-    background-color: var(--background-light);
+    /* background-color: var(--background-light); */
     font-family: var(--font-serif);
 }
 
@@ -24,6 +24,22 @@
 
 .text-size-big {
     font-size: 1.2rem;
+}
+
+.bg-white {
+    background-color: var(--background-light);
+}
+
+.bg-offwhite {
+    background-color: var(--bg-reading-offwhite);
+}
+
+.bg-yellow {
+    background-color: var(--bg-reading-yellow);
+}
+
+.bg-blue {
+    background-color: var(--bg-reading-blue);
 }
 
 @media only screen and (max-width:400px) {

--- a/client/src/components/TextView/TextContent/TextContent.css
+++ b/client/src/components/TextView/TextContent/TextContent.css
@@ -54,6 +54,19 @@
     margin-right: 2rem;
 }
 
+
+.spacing-0 {
+    line-height: 1.2;
+}
+
+.spacing-1 {
+    line-height: 1.5;
+}
+
+.spacing-2 {
+    line-height: 2;
+}
+
 @media only screen and (max-width:400px) {
     .storyPage {
         max-width: 100vw;

--- a/client/src/components/TextView/TextContent/TextContent.css
+++ b/client/src/components/TextView/TextContent/TextContent.css
@@ -9,7 +9,7 @@
     max-width: 50vw;
     height: 90vh;
     /* padding: 4rem 2rem; */
-    padding: 8rem 2rem;
+    /* padding: 8rem 2rem; */
     /* background-color: var(--background-light); */
     font-family: var(--font-serif);
 }
@@ -32,6 +32,26 @@
 
 .font-sans-serif {
     font-family: var(--font-sans-serif);
+}
+
+.margins-0 {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+}
+
+.margins-1 {
+    margin-left: 1rem;
+    margin-right: 1rem;
+}
+
+.margins-2 {
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+}
+
+.margins-3 {
+    margin-left: 2rem;
+    margin-right: 2rem;
 }
 
 @media only screen and (max-width:400px) {

--- a/client/src/components/TextView/TextContent/TextContent.css
+++ b/client/src/components/TextView/TextContent/TextContent.css
@@ -1,15 +1,27 @@
 .storyPage {
-width: 50vw;
-height: 90vh;
-/* padding: 4rem 2rem; */
-padding: 8rem 2rem;
-background-color: var(--background-light);
-font-family: var(--font-serif);
+    width: 50vw;
+    height: 90vh;
+    /* padding: 4rem 2rem; */
+    padding: 8rem 2rem;
+    /* background-color: var(--background-light); */
+    font-family: var(--font-serif);
 }
 
-@media only screen and (max-width:400px){
+.text-size-small {
+    font-size: 0.85rem;
+}
+
+.text-size-regular {
+    font-size: 1rem;
+}
+
+.text-size-big {
+    font-size: 1.2rem;
+}
+
+@media only screen and (max-width:400px) {
     .storyPage {
         width: 100vw;
-        font-size: smaller;
+        /* font-size: smaller; */
     }
 }

--- a/client/src/components/TextView/TextContent/TextContent.css
+++ b/client/src/components/TextView/TextContent/TextContent.css
@@ -26,20 +26,12 @@
     font-size: 1.2rem;
 }
 
-.bg-white {
-    background-color: var(--background-light);
+.font-serif {
+    font-family: var(--font-serif);
 }
 
-.bg-offwhite {
-    background-color: var(--bg-reading-offwhite);
-}
-
-.bg-yellow {
-    background-color: var(--bg-reading-yellow);
-}
-
-.bg-blue {
-    background-color: var(--bg-reading-blue);
+.font-sans-serif {
+    font-family: var(--font-sans-serif);
 }
 
 @media only screen and (max-width:400px) {

--- a/client/src/components/TextView/TextContent/TextContent.js
+++ b/client/src/components/TextView/TextContent/TextContent.js
@@ -5,7 +5,7 @@ import './TextContent.css';
 import TextCard from './TextCard';
 import textForPages from '../../../assets/resources/sampleTextData.json';
 
-const TextContent = ({textSizeClass, fontClass}) => {
+const TextContent = ({textSizeClass, fontClass, marginsClass}) => {
   const responsive = {
     desktop: {
       breakpoint: { max: 3000, min: 1024 },
@@ -24,7 +24,7 @@ const TextContent = ({textSizeClass, fontClass}) => {
   };
 
   const pagesFromJson = textForPages.map((page) => (
-    <TextCard id={page.id} content={page.content} key={page.id} textSizeClass={textSizeClass} fontClass={fontClass}/>
+    <TextCard id={page.id} content={page.content} key={page.id} textSizeClass={textSizeClass} fontClass={fontClass} marginsClass={marginsClass} />
   ));
 
   return (

--- a/client/src/components/TextView/TextContent/TextContent.js
+++ b/client/src/components/TextView/TextContent/TextContent.js
@@ -5,7 +5,7 @@ import './TextContent.css';
 import TextCard from './TextCard';
 import textForPages from '../../../assets/resources/sampleTextData.json';
 
-const TextContent = () => {
+const TextContent = ({textSizeClass}) => {
   const responsive = {
     desktop: {
       breakpoint: { max: 3000, min: 1024 },
@@ -24,7 +24,7 @@ const TextContent = () => {
   };
 
   const pagesFromJson = textForPages.map((page) => (
-    <TextCard id={page.id} content={page.content} />
+    <TextCard id={page.id} content={page.content} textSizeClass={textSizeClass}/>
   ));
 
   return (

--- a/client/src/components/TextView/TextContent/TextContent.js
+++ b/client/src/components/TextView/TextContent/TextContent.js
@@ -5,7 +5,7 @@ import './TextContent.css';
 import TextCard from './TextCard';
 import textForPages from '../../../assets/resources/sampleTextData.json';
 
-const TextContent = ({textSizeClass}) => {
+const TextContent = ({textSizeClass, bgColorClass}) => {
   const responsive = {
     desktop: {
       breakpoint: { max: 3000, min: 1024 },
@@ -24,7 +24,7 @@ const TextContent = ({textSizeClass}) => {
   };
 
   const pagesFromJson = textForPages.map((page) => (
-    <TextCard id={page.id} content={page.content} key={page.id} textSizeClass={textSizeClass}/>
+    <TextCard id={page.id} content={page.content} key={page.id} textSizeClass={textSizeClass} bgColorClass={bgColorClass}/>
   ));
 
   return (

--- a/client/src/components/TextView/TextContent/TextContent.js
+++ b/client/src/components/TextView/TextContent/TextContent.js
@@ -5,7 +5,7 @@ import './TextContent.css';
 import TextCard from './TextCard';
 import textForPages from '../../../assets/resources/sampleTextData.json';
 
-const TextContent = ({textSizeClass, fontClass, marginsClass}) => {
+const TextContent = ({textSizeClass, fontClass, marginsClass, spacingClass}) => {
   const responsive = {
     desktop: {
       breakpoint: { max: 3000, min: 1024 },
@@ -24,7 +24,7 @@ const TextContent = ({textSizeClass, fontClass, marginsClass}) => {
   };
 
   const pagesFromJson = textForPages.map((page) => (
-    <TextCard id={page.id} content={page.content} key={page.id} textSizeClass={textSizeClass} fontClass={fontClass} marginsClass={marginsClass} />
+    <TextCard id={page.id} content={page.content} key={page.id} textSizeClass={textSizeClass} fontClass={fontClass} marginsClass={marginsClass} spacingClass={spacingClass} />
   ));
 
   return (

--- a/client/src/components/TextView/TextContent/TextContent.js
+++ b/client/src/components/TextView/TextContent/TextContent.js
@@ -5,7 +5,7 @@ import './TextContent.css';
 import TextCard from './TextCard';
 import textForPages from '../../../assets/resources/sampleTextData.json';
 
-const TextContent = ({textSizeClass, bgColorClass}) => {
+const TextContent = ({textSizeClass, fontClass}) => {
   const responsive = {
     desktop: {
       breakpoint: { max: 3000, min: 1024 },
@@ -24,7 +24,7 @@ const TextContent = ({textSizeClass, bgColorClass}) => {
   };
 
   const pagesFromJson = textForPages.map((page) => (
-    <TextCard id={page.id} content={page.content} key={page.id} textSizeClass={textSizeClass} bgColorClass={bgColorClass}/>
+    <TextCard id={page.id} content={page.content} key={page.id} textSizeClass={textSizeClass} fontClass={fontClass}/>
   ));
 
   return (

--- a/client/src/components/TextView/TextContent/TextContent.js
+++ b/client/src/components/TextView/TextContent/TextContent.js
@@ -29,9 +29,9 @@ const TextContent = ({toggleReadingNavOpen, textSizeClass, fontClass, marginsCla
 
   return (
     <div className="textContentContainer">
-    <Carousel responsive={responsive} removeArrowOnDeviceType={['mobile']} sliderClass='text-pages-carousel-track'>
-      {pagesFromJson}
-    </Carousel>
+      <Carousel responsive={responsive} removeArrowOnDeviceType={['mobile']} sliderClass='text-pages-carousel-track'>
+        {pagesFromJson}
+      </Carousel>
     </div>
   );
 };

--- a/client/src/components/TextView/TextContent/TextContent.js
+++ b/client/src/components/TextView/TextContent/TextContent.js
@@ -29,7 +29,7 @@ const TextContent = ({textSizeClass, fontClass, marginsClass, spacingClass}) => 
 
   return (
     <div className="textContentContainer">
-    <Carousel responsive={responsive} removeArrowOnDeviceType={['mobile']}>
+    <Carousel responsive={responsive} removeArrowOnDeviceType={['mobile']} sliderClass='text-pages-carousel-track'>
       {pagesFromJson}
     </Carousel>
     </div>

--- a/client/src/components/TextView/TextContent/TextContent.js
+++ b/client/src/components/TextView/TextContent/TextContent.js
@@ -5,7 +5,7 @@ import './TextContent.css';
 import TextCard from './TextCard';
 import textForPages from '../../../assets/resources/sampleTextData.json';
 
-const TextContent = ({textSizeClass, fontClass, marginsClass, spacingClass}) => {
+const TextContent = ({toggleReadingNavOpen, textSizeClass, fontClass, marginsClass, spacingClass}) => {
   const responsive = {
     desktop: {
       breakpoint: { max: 3000, min: 1024 },
@@ -24,7 +24,7 @@ const TextContent = ({textSizeClass, fontClass, marginsClass, spacingClass}) => 
   };
 
   const pagesFromJson = textForPages.map((page) => (
-    <TextCard id={page.id} content={page.content} key={page.id} textSizeClass={textSizeClass} fontClass={fontClass} marginsClass={marginsClass} spacingClass={spacingClass} />
+    <TextCard id={page.id} content={page.content} key={page.id} toggleReadingNavOpen={toggleReadingNavOpen} textSizeClass={textSizeClass} fontClass={fontClass} marginsClass={marginsClass} spacingClass={spacingClass} />
   ));
 
   return (

--- a/client/src/components/TextView/TextSettings/TextSettings.css
+++ b/client/src/components/TextView/TextSettings/TextSettings.css
@@ -1,19 +1,19 @@
-.settingsBtn{
+.settingsBtn {
     /* position: absolute;
     top:10px;
     left: 90%; */
     position: absolute;
-    top:50px;
+    top: 50px;
     left: 90%;
     z-index: 40;
 }
 
 .textSettingsContainer {
     color: var(--font-dark);
-    background: var(--background-light);
+    /* background: var(--background-light); */
     position: absolute;
     top: 50px;
-    left:0;
+    left: 0;
     /* position: absolute;
     top:0;
     left: 0; */
@@ -27,14 +27,14 @@
 }
 
 
-@media only screen and (max-width:1024px){
-    .settingsBtn{
+@media only screen and (max-width:1024px) {
+    .settingsBtn {
         left: 85%;
     }
 }
 
-@media only screen and (max-width:364px){
-    .textSettingsContainer{
+@media only screen and (max-width:364px) {
+    .textSettingsContainer {
         padding-right: 4rem;
     }
 }

--- a/client/src/components/TextView/TextSettings/TextSettings.css
+++ b/client/src/components/TextView/TextSettings/TextSettings.css
@@ -1,29 +1,31 @@
 .settingsBtn {
-    /* position: absolute;
-    top:10px;
-    left: 90%; */
     position: absolute;
     top: 0px;
     left: 90%;
     z-index: 40;
 }
 
+.textNavTop {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.textNavBottom {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+}
+
 .textSettingsContainer {
     color: var(--font-dark);
-    /* background: var(--background-light); */
-    position: absolute;
-    top: 0px;
-    left: 0;
-    /* position: absolute;
-    top:0;
-    left: 0; */
+    background: var(--background-light);
     z-index: 20;
     width: 100%;
     display: flex;
     flex-direction: row;
     justify-content: space-evenly;
     align-items: center;
-
 }
 
 

--- a/client/src/components/TextView/TextSettings/TextSettings.css
+++ b/client/src/components/TextView/TextSettings/TextSettings.css
@@ -3,7 +3,7 @@
     top:10px;
     left: 90%; */
     position: absolute;
-    top: 50px;
+    top: 0px;
     left: 90%;
     z-index: 40;
 }
@@ -12,7 +12,7 @@
     color: var(--font-dark);
     /* background: var(--background-light); */
     position: absolute;
-    top: 50px;
+    top: 0px;
     left: 0;
     /* position: absolute;
     top:0;

--- a/client/src/components/TextView/TextSettings/TextSettings.js
+++ b/client/src/components/TextView/TextSettings/TextSettings.js
@@ -4,7 +4,7 @@ import { Collapse, Button } from 'reactstrap';
 import {Link} from 'react-router-dom';
 import './TextSettings.css';
 
-const TextSettings = ({passTextSize, passBgColor}) => {
+const TextSettings = ({passTextSize, passBgColor, passFont}) => {
 
   // whole settings submenu
   const [isOpen, setIsOpen] = useState(false);
@@ -18,6 +18,10 @@ const TextSettings = ({passTextSize, passBgColor}) => {
   const [colorDropdownOpen, setColorOpen] = useState(false);
   const toggleColorDropdown = () => setColorOpen(!colorDropdownOpen);
 
+  // font dropdown
+  const [fontDropdownOpen, setFontOpen] = useState(false);
+  const toggleFontDropdown = () => setFontOpen(!fontDropdownOpen);
+
   // option handlers: text size, bg color, font, margins, line height
   const changeTextSize = (newSize) => {
     passTextSize(newSize);
@@ -25,6 +29,10 @@ const TextSettings = ({passTextSize, passBgColor}) => {
  
   const changeBgColor = (newColor) => {
     passBgColor(newColor);
+  };
+
+  const changeFont = (newFont) => {
+    passFont(newFont);
   };
 
   return (
@@ -77,9 +85,24 @@ const TextSettings = ({passTextSize, passBgColor}) => {
               </DropdownItem>
             </DropdownMenu>
           </ButtonDropdown>
-              {/* <DropdownItem> 
-                <p>Color</p>
+
+          <ButtonDropdown isOpen={fontDropdownOpen} toggle={toggleFontDropdown}>
+            <DropdownToggle color="light">
+                    Font
+            </DropdownToggle>
+            <DropdownMenu>
+              <DropdownItem header>
+                <p>Font</p>
               </DropdownItem>
+              <DropdownItem onClick={() => changeFont('serif')}> 
+                <p>Serif</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeFont('sans-serif')}> 
+                <p>Sans-Serif</p>
+              </DropdownItem>
+            </DropdownMenu>
+          </ButtonDropdown>
+              {/* 
               <DropdownItem> 
                 <p>Font</p>
               </DropdownItem>

--- a/client/src/components/TextView/TextSettings/TextSettings.js
+++ b/client/src/components/TextView/TextSettings/TextSettings.js
@@ -10,9 +10,9 @@ const TextSettings = ({passTextSize}) => {
   const [isOpen, setIsOpen] = useState(false);
   const toggle = () => setIsOpen(!isOpen);
 
-  // text modifiers dropdown
-  const [dropdownOpen, setOpen] = useState(false);
-  const toggleDropDown = () => setOpen(!dropdownOpen);
+  // text size dropdown
+  const [sizeDropdownOpen, setSizeOpen] = useState(false);
+  const toggleDropDown = () => setSizeOpen(!sizeDropdownOpen);
 
   // text size
   const changeTextSize = (newSize) => {
@@ -28,7 +28,7 @@ const TextSettings = ({passTextSize}) => {
          
 
           {/* This dropdown menu is intended for the reader to adjust the page view into their liking */}
-          <ButtonDropdown isOpen={dropdownOpen} toggle={toggleDropDown}>
+          <ButtonDropdown isOpen={sizeDropdownOpen} toggle={toggleDropDown}>
             <DropdownToggle color="light">
                     Aa
             </DropdownToggle>

--- a/client/src/components/TextView/TextSettings/TextSettings.js
+++ b/client/src/components/TextView/TextSettings/TextSettings.js
@@ -103,9 +103,9 @@ const TextSettings = ({isReadingNavOpen, passTextSize, passBgColor, passFont, pa
                     Font
             </DropdownToggle>
             <DropdownMenu>
-              <DropdownItem header>
+              {/*  <DropdownItem header>
                 <p>Font</p>
-              </DropdownItem>
+              </DropdownItem> */}
               <DropdownItem onClick={() => changeFont('serif')}> 
                 <p>Serif</p>
               </DropdownItem>
@@ -120,9 +120,9 @@ const TextSettings = ({isReadingNavOpen, passTextSize, passBgColor, passFont, pa
                     Margins
             </DropdownToggle>
             <DropdownMenu>
-              <DropdownItem header>
+              {/*   <DropdownItem header>
                 <p>Margins</p>
-              </DropdownItem>
+              </DropdownItem> */}
               <DropdownItem onClick={() => changeMargins('0')}> 
                 <p>None</p>
               </DropdownItem>
@@ -162,7 +162,7 @@ const TextSettings = ({isReadingNavOpen, passTextSize, passBgColor, passFont, pa
       </Collapse>
 
       <Collapse isOpen={isReadingNavOpen} >
-      <div className="textNavBottom textSettingsContainer">
+        <div className="textNavBottom textSettingsContainer">
 
           {/* A search function could be implemented here. Kindle has this feature. */}
           <Button color="light"><i className="fas fa-search"></i></Button>    
@@ -175,7 +175,7 @@ const TextSettings = ({isReadingNavOpen, passTextSize, passBgColor, passFont, pa
 
           <Link to="/"><Button color="light"><i className="fas fa-home"></i></Button> </Link>
 
-      </div>
+        </div>
       </Collapse>
     </div>
   );

--- a/client/src/components/TextView/TextSettings/TextSettings.js
+++ b/client/src/components/TextView/TextSettings/TextSettings.js
@@ -56,7 +56,7 @@ const TextSettings = ({passTextSize, passBgColor, passFont, passMargins, passSpa
       <Button color="light" onClick={toggle} className="settingsBtn"><i className="fas fa-cog"></i></Button>
       <Collapse isOpen={isOpen}>
 
-        <div className="textSettingsContainer">
+        <div className="textNavTop textSettingsContainer">
          
           {/* This dropdown menus are intended for the reader to adjust the page view into their liking */}
           <ButtonDropdown isOpen={sizeDropdownOpen} toggle={toggleSizeDropdown}>
@@ -146,7 +146,7 @@ const TextSettings = ({passTextSize, passBgColor, passFont, passMargins, passSpa
             <DropdownToggle color="light">
                     Spacing
             </DropdownToggle>
-            <DropdownMenu>
+            <DropdownMenu right>
               <DropdownItem header>
                 <p>Spacing</p>
               </DropdownItem>
@@ -162,23 +162,23 @@ const TextSettings = ({passTextSize, passBgColor, passFont, passMargins, passSpa
             </DropdownMenu>
           </ButtonDropdown>
 
+        </div>
+      </Collapse>
+
+      <Collapse isOpen={isOpen} >
+      <div className="textNavBottom textSettingsContainer">
+
           {/* A search function could be implemented here. Kindle has this feature. */}
           <Button color="light"><i className="fas fa-search"></i></Button>    
 
           {/* Functionality to add a bookmark on a page could be implemented here. Kindle has this feature. */}
           <Button color="light"><i className="fas fa-bookmark"></i></Button>        
 
-          <Link to="/">Home</Link>
+          <Link to="/"><Button color="light"><i className="fas fa-home"></i></Button> </Link>
 
-        </div>
+      </div>
       </Collapse>
     </div>
-
-
-
- 
-    
-    
   );
 };
 

--- a/client/src/components/TextView/TextSettings/TextSettings.js
+++ b/client/src/components/TextView/TextSettings/TextSettings.js
@@ -4,7 +4,7 @@ import { Collapse, Button } from 'reactstrap';
 import {Link} from 'react-router-dom';
 import './TextSettings.css';
 
-const TextSettings = ({passTextSize, passBgColor, passFont}) => {
+const TextSettings = ({passTextSize, passBgColor, passFont, passMargins}) => {
 
   // whole settings submenu
   const [isOpen, setIsOpen] = useState(false);
@@ -21,6 +21,10 @@ const TextSettings = ({passTextSize, passBgColor, passFont}) => {
   // font dropdown
   const [fontDropdownOpen, setFontOpen] = useState(false);
   const toggleFontDropdown = () => setFontOpen(!fontDropdownOpen);
+ 
+  // margins dropdown
+  const [marginsDropdownOpen, setMarginsOpen] = useState(false);
+  const toggleMarginsDropdown = () => setMarginsOpen(!marginsDropdownOpen);
 
   // option handlers: text size, bg color, font, margins, line height
   const changeTextSize = (newSize) => {
@@ -33,6 +37,10 @@ const TextSettings = ({passTextSize, passBgColor, passFont}) => {
 
   const changeFont = (newFont) => {
     passFont(newFont);
+  };
+
+  const changeMargins = (newMargins) => {
+    passMargins(newMargins);
   };
 
   return (
@@ -102,13 +110,29 @@ const TextSettings = ({passTextSize, passBgColor, passFont}) => {
               </DropdownItem>
             </DropdownMenu>
           </ButtonDropdown>
-              {/* 
-              <DropdownItem> 
-                <p>Font</p>
-              </DropdownItem>
-              <DropdownItem> 
+
+          <ButtonDropdown isOpen={marginsDropdownOpen} toggle={toggleMarginsDropdown}>
+            <DropdownToggle color="light">
+                    Margins
+            </DropdownToggle>
+            <DropdownMenu>
+              <DropdownItem header>
                 <p>Margins</p>
-              </DropdownItem> */}
+              </DropdownItem>
+              <DropdownItem onClick={() => changeMargins('0')}> 
+                <p>None</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeMargins('1')}> 
+                <p>Small</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeMargins('2')}> 
+                <p>Medium</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeMargins('3')}> 
+                <p>Big</p>
+              </DropdownItem>
+            </DropdownMenu>
+          </ButtonDropdown>
 
           {/* A search function could be implemented here. Kindle has this feature. */}
           <Button color="light"><i className="fas fa-search"></i></Button>    

--- a/client/src/components/TextView/TextSettings/TextSettings.js
+++ b/client/src/components/TextView/TextSettings/TextSettings.js
@@ -4,11 +4,7 @@ import { Collapse, Button } from 'reactstrap';
 import {Link} from 'react-router-dom';
 import './TextSettings.css';
 
-const TextSettings = ({passTextSize, passBgColor, passFont, passMargins, passSpacing}) => {
-
-  // whole settings submenu
-  const [isOpen, setIsOpen] = useState(false);
-  const toggle = () => setIsOpen(!isOpen);
+const TextSettings = ({isReadingNavOpen, passTextSize, passBgColor, passFont, passMargins, passSpacing}) => {
 
   // text size dropdown
   const [sizeDropdownOpen, setSizeOpen] = useState(false);
@@ -53,8 +49,7 @@ const TextSettings = ({passTextSize, passBgColor, passFont, passMargins, passSpa
 
   return (
     <div>
-      <Button color="light" onClick={toggle} className="settingsBtn"><i className="fas fa-cog"></i></Button>
-      <Collapse isOpen={isOpen}>
+      <Collapse isOpen={isReadingNavOpen}>
 
         <div className="textNavTop textSettingsContainer">
          
@@ -165,14 +160,16 @@ const TextSettings = ({passTextSize, passBgColor, passFont, passMargins, passSpa
         </div>
       </Collapse>
 
-      <Collapse isOpen={isOpen} >
+      <Collapse isOpen={isReadingNavOpen} >
       <div className="textNavBottom textSettingsContainer">
 
           {/* A search function could be implemented here. Kindle has this feature. */}
           <Button color="light"><i className="fas fa-search"></i></Button>    
 
           {/* Functionality to add a bookmark on a page could be implemented here. Kindle has this feature. */}
-          <Button color="light"><i className="fas fa-bookmark"></i></Button>        
+          <Button color="light"><i className="fas fa-bookmark"></i></Button>  
+
+          {/* Add "Back to details page" instead fo the bookmark? */}      
 
           <Link to="/"><Button color="light"><i className="fas fa-home"></i></Button> </Link>
 

--- a/client/src/components/TextView/TextSettings/TextSettings.js
+++ b/client/src/components/TextView/TextSettings/TextSettings.js
@@ -4,7 +4,7 @@ import { Collapse, Button } from 'reactstrap';
 import {Link} from 'react-router-dom';
 import './TextSettings.css';
 
-const TextSettings = ({passTextSize}) => {
+const TextSettings = ({passTextSize, passBgColor}) => {
 
   // whole settings submenu
   const [isOpen, setIsOpen] = useState(false);
@@ -12,11 +12,19 @@ const TextSettings = ({passTextSize}) => {
 
   // text size dropdown
   const [sizeDropdownOpen, setSizeOpen] = useState(false);
-  const toggleDropDown = () => setSizeOpen(!sizeDropdownOpen);
+  const toggleSizeDropdown = () => setSizeOpen(!sizeDropdownOpen);
 
-  // text size
+  // text color dropdown
+  const [colorDropdownOpen, setColorOpen] = useState(false);
+  const toggleColorDropdown = () => setColorOpen(!colorDropdownOpen);
+
+  // option handlers: text size, bg color, font, margins, line height
   const changeTextSize = (newSize) => {
     passTextSize(newSize);
+  };
+ 
+  const changeBgColor = (newColor) => {
+    passBgColor(newColor);
   };
 
   return (
@@ -26,31 +34,50 @@ const TextSettings = ({passTextSize}) => {
 
         <div className="textSettingsContainer">
          
-
-          {/* This dropdown menu is intended for the reader to adjust the page view into their liking */}
-          <ButtonDropdown isOpen={sizeDropdownOpen} toggle={toggleDropDown}>
+          {/* This dropdown menus are intended for the reader to adjust the page view into their liking */}
+          <ButtonDropdown isOpen={sizeDropdownOpen} toggle={toggleSizeDropdown}>
             <DropdownToggle color="light">
                     Aa
             </DropdownToggle>
             <DropdownMenu>
               <DropdownItem header>
-                <p>Text modifiers</p>
-              </DropdownItem>
-
-              <DropdownItem> 
-                <p>Text Size</p>
+                <p>Text size</p>
               </DropdownItem>
               <DropdownItem onClick={() => changeTextSize('small')}> 
-                <p>-- Small</p>
+                <p>Small</p>
               </DropdownItem>
               <DropdownItem onClick={() => changeTextSize('regular')}> 
-                <p>-- Regular</p>
+                <p>Regular</p>
               </DropdownItem>
               <DropdownItem onClick={() => changeTextSize('big')}> 
-                <p>-- Big</p>
+                <p>Big</p>
               </DropdownItem>
+            </DropdownMenu>
+          </ButtonDropdown>
 
-              <DropdownItem> 
+          <ButtonDropdown isOpen={colorDropdownOpen} toggle={toggleColorDropdown}>
+            <DropdownToggle color="light">
+                    Color
+            </DropdownToggle>
+            <DropdownMenu>
+              <DropdownItem header>
+                <p>Background color</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeBgColor('white')}> 
+                <p>White</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeBgColor('offwhite')}> 
+                <p>Off-White</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeBgColor('yellow')}> 
+                <p>Yellow</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeBgColor('blue')}> 
+                <p>Blue</p>
+              </DropdownItem>
+            </DropdownMenu>
+          </ButtonDropdown>
+              {/* <DropdownItem> 
                 <p>Color</p>
               </DropdownItem>
               <DropdownItem> 
@@ -58,9 +85,7 @@ const TextSettings = ({passTextSize}) => {
               </DropdownItem>
               <DropdownItem> 
                 <p>Margins</p>
-              </DropdownItem>
-            </DropdownMenu>
-          </ButtonDropdown>
+              </DropdownItem> */}
 
           {/* A search function could be implemented here. Kindle has this feature. */}
           <Button color="light"><i className="fas fa-search"></i></Button>    

--- a/client/src/components/TextView/TextSettings/TextSettings.js
+++ b/client/src/components/TextView/TextSettings/TextSettings.js
@@ -4,15 +4,20 @@ import { Collapse, Button } from 'reactstrap';
 import {Link} from 'react-router-dom';
 import './TextSettings.css';
 
-const TextSettings = () => {
+const TextSettings = ({passTextSize}) => {
 
+  // whole settings submenu
   const [isOpen, setIsOpen] = useState(false);
-
   const toggle = () => setIsOpen(!isOpen);
 
+  // text modifiers dropdown
   const [dropdownOpen, setOpen] = useState(false);
-
   const toggleDropDown = () => setOpen(!dropdownOpen);
+
+  // text size
+  const changeTextSize = (newSize) => {
+    passTextSize(newSize);
+  };
 
   return (
     <div>
@@ -31,9 +36,20 @@ const TextSettings = () => {
               <DropdownItem header>
                 <p>Text modifiers</p>
               </DropdownItem>
+
               <DropdownItem> 
                 <p>Text Size</p>
               </DropdownItem>
+              <DropdownItem onClick={() => changeTextSize('small')}> 
+                <p>-- Small</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeTextSize('regular')}> 
+                <p>-- Regular</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeTextSize('big')}> 
+                <p>-- Big</p>
+              </DropdownItem>
+
               <DropdownItem> 
                 <p>Color</p>
               </DropdownItem>

--- a/client/src/components/TextView/TextSettings/TextSettings.js
+++ b/client/src/components/TextView/TextSettings/TextSettings.js
@@ -4,7 +4,7 @@ import { Collapse, Button } from 'reactstrap';
 import {Link} from 'react-router-dom';
 import './TextSettings.css';
 
-const TextSettings = ({passTextSize, passBgColor, passFont, passMargins}) => {
+const TextSettings = ({passTextSize, passBgColor, passFont, passMargins, passSpacing}) => {
 
   // whole settings submenu
   const [isOpen, setIsOpen] = useState(false);
@@ -25,6 +25,10 @@ const TextSettings = ({passTextSize, passBgColor, passFont, passMargins}) => {
   // margins dropdown
   const [marginsDropdownOpen, setMarginsOpen] = useState(false);
   const toggleMarginsDropdown = () => setMarginsOpen(!marginsDropdownOpen);
+ 
+  // line height dropdown
+  const [spacingDropdownOpen, setSpacingOpen] = useState(false);
+  const toggleSpacingDropdown = () => setSpacingOpen(!spacingDropdownOpen);
 
   // option handlers: text size, bg color, font, margins, line height
   const changeTextSize = (newSize) => {
@@ -41,6 +45,10 @@ const TextSettings = ({passTextSize, passBgColor, passFont, passMargins}) => {
 
   const changeMargins = (newMargins) => {
     passMargins(newMargins);
+  };
+
+  const changeSpacing = (newSpacing) => {
+    passSpacing(newSpacing);
   };
 
   return (
@@ -129,6 +137,26 @@ const TextSettings = ({passTextSize, passBgColor, passFont, passMargins}) => {
                 <p>Medium</p>
               </DropdownItem>
               <DropdownItem onClick={() => changeMargins('3')}> 
+                <p>Big</p>
+              </DropdownItem>
+            </DropdownMenu>
+          </ButtonDropdown>
+
+          <ButtonDropdown isOpen={spacingDropdownOpen} toggle={toggleSpacingDropdown}>
+            <DropdownToggle color="light">
+                    Spacing
+            </DropdownToggle>
+            <DropdownMenu>
+              <DropdownItem header>
+                <p>Spacing</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeSpacing('0')}> 
+                <p>Small</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeSpacing('1')}> 
+                <p>Regular</p>
+              </DropdownItem>
+              <DropdownItem onClick={() => changeSpacing('2')}> 
                 <p>Big</p>
               </DropdownItem>
             </DropdownMenu>

--- a/client/src/components/TextView/TextSettings/TextSettings.js
+++ b/client/src/components/TextView/TextSettings/TextSettings.js
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
+import { withRouter } from 'react-router-dom';
 import { ButtonDropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
 import { Collapse, Button } from 'reactstrap';
 import {Link} from 'react-router-dom';
 import './TextSettings.css';
 
-const TextSettings = ({isReadingNavOpen, passTextSize, passBgColor, passFont, passMargins, passSpacing}) => {
+const TextSettings = ({isReadingNavOpen, passTextSize, passBgColor, passFont, passMargins, passSpacing, history}) => {
 
   // text size dropdown
   const [sizeDropdownOpen, setSizeOpen] = useState(false);
@@ -169,7 +170,8 @@ const TextSettings = ({isReadingNavOpen, passTextSize, passBgColor, passFont, pa
           {/* Functionality to add a bookmark on a page could be implemented here. Kindle has this feature. */}
           <Button color="light"><i className="fas fa-bookmark"></i></Button>  
 
-          {/* Add "Back to details page" instead fo the bookmark? */}      
+          {/* Back to Details page */}
+          <Button color="light" onClick={() => history.goBack()}><i className="fas fa-book"></i></Button>
 
           <Link to="/"><Button color="light"><i className="fas fa-home"></i></Button> </Link>
 
@@ -179,4 +181,4 @@ const TextSettings = ({isReadingNavOpen, passTextSize, passBgColor, passFont, pa
   );
 };
 
-export default TextSettings;
+export default withRouter(TextSettings);

--- a/client/src/pages/TextPage.css
+++ b/client/src/pages/TextPage.css
@@ -1,5 +1,5 @@
 .textPage {
     background-color: var(--background-light);
-    height:100vh;
-    width:100vw;
+    height: 100vh;
+    width: 100vw;
 }

--- a/client/src/pages/TextPage.css
+++ b/client/src/pages/TextPage.css
@@ -5,11 +5,11 @@
 }
 
 .bg-white {
-    background-color: var(--background-light);
+    background-color: var(--bg-reading-white);
 }
 
 .bg-offwhite {
-    background-color: var(--bg-reading-offwhite);
+    background-color: var(--background-light);
 }
 
 .bg-yellow {

--- a/client/src/pages/TextPage.css
+++ b/client/src/pages/TextPage.css
@@ -1,5 +1,21 @@
 .textPage {
-    background-color: var(--background-light);
+    /* background-color: var(--background-light); */
     height: 100vh;
     width: 100vw;
+}
+
+.bg-white {
+    background-color: var(--background-light);
+}
+
+.bg-offwhite {
+    background-color: var(--bg-reading-offwhite);
+}
+
+.bg-yellow {
+    background-color: var(--bg-reading-yellow);
+}
+
+.bg-blue {
+    background-color: var(--bg-reading-blue);
 }

--- a/client/src/pages/TextPage.js
+++ b/client/src/pages/TextPage.js
@@ -4,11 +4,14 @@ import TextSettings from '../components/TextView/TextSettings/TextSettings';
 import './TextPage.css';
 
 const TextPage = () => {
+  const [isReadingNavOpen, setIsReadingNavOpen] = useState(false);
   const [textSize, setTextSize] = useState('regular');
   const [bgColor, setBgColor] = useState('offwhite');
   const [font, setFont] = useState('serif');
   const [margins, setMargins] = useState('2');
   const [spacing, setSpacing] = useState('1');
+
+  const toggleReadingNavOpen = () => setIsReadingNavOpen(!isReadingNavOpen);
 
   const handleTextSize = (newSize) => {
     setTextSize(newSize);
@@ -32,8 +35,8 @@ const TextPage = () => {
 
   return (
     <div className={`textPage bg-${bgColor}`}>
-      <TextSettings passTextSize={handleTextSize} passBgColor={handleBgColor} passFont={handleFont} passMargins={handleMargins} passSpacing={handleSpacing} />
-      <TextContent textSizeClass={textSize} fontClass={font} marginsClass={margins} spacingClass={spacing} />
+      <TextSettings isReadingNavOpen={isReadingNavOpen} passTextSize={handleTextSize} passBgColor={handleBgColor} passFont={handleFont} passMargins={handleMargins} passSpacing={handleSpacing} />
+      <TextContent toggleReadingNavOpen={toggleReadingNavOpen} textSizeClass={textSize} fontClass={font} marginsClass={margins} spacingClass={spacing} />
     </div>
   );
 };

--- a/client/src/pages/TextPage.js
+++ b/client/src/pages/TextPage.js
@@ -7,6 +7,7 @@ const TextPage = () => {
   const [textSize, setTextSize] = useState('regular');
   const [bgColor, setBgColor] = useState('offwhite');
   const [font, setFont] = useState('serif');
+  const [margins, setMargins] = useState('2');
 
   const handleTextSize = (newSize) => {
     setTextSize(newSize);
@@ -20,10 +21,14 @@ const TextPage = () => {
     setFont(newFont);
   };
 
+  const handleMargins = (newMargins) => {
+    setMargins(newMargins);
+  };
+
   return (
     <div className={`textPage bg-${bgColor}`}>
-      <TextSettings passTextSize={handleTextSize} passBgColor={handleBgColor} passFont={handleFont} />
-      <TextContent textSizeClass={textSize} fontClass={font} />
+      <TextSettings passTextSize={handleTextSize} passBgColor={handleBgColor} passFont={handleFont} passMargins={handleMargins}/>
+      <TextContent textSizeClass={textSize} fontClass={font} marginsClass={margins} />
     </div>
   );
 };

--- a/client/src/pages/TextPage.js
+++ b/client/src/pages/TextPage.js
@@ -8,6 +8,7 @@ const TextPage = () => {
   const [bgColor, setBgColor] = useState('offwhite');
   const [font, setFont] = useState('serif');
   const [margins, setMargins] = useState('2');
+  const [spacing, setSpacing] = useState('1');
 
   const handleTextSize = (newSize) => {
     setTextSize(newSize);
@@ -25,10 +26,14 @@ const TextPage = () => {
     setMargins(newMargins);
   };
 
+  const handleSpacing = (newSpacing) => {
+    setSpacing(newSpacing);
+  };
+
   return (
     <div className={`textPage bg-${bgColor}`}>
-      <TextSettings passTextSize={handleTextSize} passBgColor={handleBgColor} passFont={handleFont} passMargins={handleMargins}/>
-      <TextContent textSizeClass={textSize} fontClass={font} marginsClass={margins} />
+      <TextSettings passTextSize={handleTextSize} passBgColor={handleBgColor} passFont={handleFont} passMargins={handleMargins} passSpacing={handleSpacing} />
+      <TextContent textSizeClass={textSize} fontClass={font} marginsClass={margins} spacingClass={spacing} />
     </div>
   );
 };

--- a/client/src/pages/TextPage.js
+++ b/client/src/pages/TextPage.js
@@ -1,13 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import TextContent from '../components/TextView/TextContent/TextContent';
 import TextSettings from '../components/TextView/TextSettings/TextSettings';
 import './TextPage.css';
 
 const TextPage = () => {
+  const [textSize, setTextSize] = useState('regular');
+  const handleTextSize = (newSize) => {
+    setTextSize(newSize);
+    console.log('newSize', newSize);
+    console.log('textSize', textSize);
+  };
+
   return (
     <div className="textPage">
-      <TextSettings/>
-      <TextContent/>
+      <TextSettings passTextSize={handleTextSize}/>
+      <TextContent textSizeClass={textSize}/>
     </div>
   );
 };

--- a/client/src/pages/TextPage.js
+++ b/client/src/pages/TextPage.js
@@ -5,16 +5,20 @@ import './TextPage.css';
 
 const TextPage = () => {
   const [textSize, setTextSize] = useState('regular');
+  const [bgColor, setBgColor] = useState('offwhite');
+
   const handleTextSize = (newSize) => {
     setTextSize(newSize);
-    console.log('newSize', newSize);
-    console.log('textSize', textSize);
+  };
+
+  const handleBgColor = (newColor) => {
+    setBgColor(newColor);
   };
 
   return (
     <div className="textPage">
-      <TextSettings passTextSize={handleTextSize}/>
-      <TextContent textSizeClass={textSize}/>
+      <TextSettings passTextSize={handleTextSize} passBgColor={handleBgColor}/>
+      <TextContent textSizeClass={textSize} bgColorClass={bgColor}/>
     </div>
   );
 };

--- a/client/src/pages/TextPage.js
+++ b/client/src/pages/TextPage.js
@@ -6,6 +6,7 @@ import './TextPage.css';
 const TextPage = () => {
   const [textSize, setTextSize] = useState('regular');
   const [bgColor, setBgColor] = useState('offwhite');
+  const [font, setFont] = useState('serif');
 
   const handleTextSize = (newSize) => {
     setTextSize(newSize);
@@ -15,10 +16,14 @@ const TextPage = () => {
     setBgColor(newColor);
   };
 
+  const handleFont = (newFont) => {
+    setFont(newFont);
+  };
+
   return (
-    <div className="textPage">
-      <TextSettings passTextSize={handleTextSize} passBgColor={handleBgColor}/>
-      <TextContent textSizeClass={textSize} bgColorClass={bgColor}/>
+    <div className={`textPage bg-${bgColor}`}>
+      <TextSettings passTextSize={handleTextSize} passBgColor={handleBgColor} passFont={handleFont} />
+      <TextContent textSizeClass={textSize} fontClass={font} />
     </div>
   );
 };

--- a/client/src/styles/variables.css
+++ b/client/src/styles/variables.css
@@ -8,10 +8,14 @@ imported into individual stylesheets */
     --main-secondary: #4ADD58;
     --neon-primary: #BB64FF;
     --neon-secondary: #3DFF50;
-    --dark-primary: #A02FF8 ;
-    --dark-secondary:#04DB19;
-    --background-dark:black;
+    --dark-primary: #A02FF8;
+    --dark-secondary: #04DB19;
+    --background-dark: black;
     --background-light: #F9F9F9;
+    /* background colors for text pages */
+    --bg-reading-offwhite: #F9F9F9;
+    --bg-reading-yellow: #FDFFE2;
+    --bg-reading-blue: #F5FEFF;
     --font-light: white;
     --font-dark: black;
     --font-sans-serif: 'Open Sans', sans-serif;

--- a/client/src/styles/variables.css
+++ b/client/src/styles/variables.css
@@ -13,7 +13,7 @@ imported into individual stylesheets */
     --background-dark: black;
     --background-light: #F9F9F9;
     /* background colors for text pages */
-    --bg-reading-offwhite: #F9F9F9;
+    --bg-reading-white: white;
     --bg-reading-yellow: #FDFFE2;
     --bg-reading-blue: #F5FEFF;
     --font-light: white;


### PR DESCRIPTION
- black, main NavBar taken away from the reading view
- settings to change the look of the text pages: font, font size, bg color, spacing, margins
- settings and other buttons split into two navbars
- the two navbars open and close on click anywhere in the text page
- "back to book page" button in reading view
- cleaned up NavBar (the main, black one)